### PR TITLE
Qu1 047

### DIFF
--- a/src/__test__/qu1/execute.test.ts
+++ b/src/__test__/qu1/execute.test.ts
@@ -1,39 +1,58 @@
-import { describe, expect } from '@jest/globals';
-import { main } from '@/logic/qu1/execute';
-import { FOUR_OF_A_KIND, FULL_HOUSE, HIGH_CARD, ONE_PAIR, STRAIGHT, THREE_OF_A_KIND, TWO_PAIR } from '@/logic/qu1/constants';
+import { describe, expect } from "@jest/globals";
+import { main } from "@/logic/qu1/execute";
+import {
+  FOUR_OF_A_KIND,
+  FULL_HOUSE,
+  HIGH_CARD,
+  ONE_PAIR,
+  STRAIGHT,
+  THREE_OF_A_KIND,
+  TWO_PAIR,
+} from "@/logic/qu1/constants";
 
-
-describe('main test', () => {
+describe("main test", () => {
   test.each([
-    ['15111', FOUR_OF_A_KIND],
-    ['29222', FOUR_OF_A_KIND],
-    ['91999', FOUR_OF_A_KIND],
-    ['65656', FULL_HOUSE],
-    ['23233', FULL_HOUSE],
-    ['97977', FULL_HOUSE],
-    ['81181', FULL_HOUSE],
-    ['32154', STRAIGHT],
-    ['65342', STRAIGHT],
-    ['73456', STRAIGHT],
-    ['95876', STRAIGHT],
-    ['52922', THREE_OF_A_KIND],
-    ['61411', THREE_OF_A_KIND],
-    ['85755', THREE_OF_A_KIND],
-    ['39433', THREE_OF_A_KIND],
-    ['35153', TWO_PAIR],
-    ['47224', TWO_PAIR],
-    ['61816', TWO_PAIR],
-    ['41631', ONE_PAIR],
-    ['75224', ONE_PAIR],
-    ['93673', ONE_PAIR],
-    ['84954', ONE_PAIR],
-    ['64353', ONE_PAIR],
-    ['95213', HIGH_CARD],
-    ['81946', HIGH_CARD],
-    ['37582', HIGH_CARD],
-    ['91765', HIGH_CARD],
-    ['62143', HIGH_CARD]
-  ])('hand: %s should return %s', (hand, expected) => {
+    ["15111", FOUR_OF_A_KIND],
+    ["29222", FOUR_OF_A_KIND],
+    ["91999", FOUR_OF_A_KIND],
+    ["65656", FULL_HOUSE],
+    ["23233", FULL_HOUSE],
+    ["97977", FULL_HOUSE],
+    ["81181", FULL_HOUSE],
+    ["32154", STRAIGHT],
+    ["65342", STRAIGHT],
+    ["73456", STRAIGHT],
+    ["95876", STRAIGHT],
+    ["52922", THREE_OF_A_KIND],
+    ["61411", THREE_OF_A_KIND],
+    ["85755", THREE_OF_A_KIND],
+    ["39433", THREE_OF_A_KIND],
+    ["35153", TWO_PAIR],
+    ["47224", TWO_PAIR],
+    ["61816", TWO_PAIR],
+    ["41631", ONE_PAIR],
+    ["75224", ONE_PAIR],
+    ["93673", ONE_PAIR],
+    ["84954", ONE_PAIR],
+    ["64353", ONE_PAIR],
+    ["95213", HIGH_CARD],
+    ["81946", HIGH_CARD],
+    ["37582", HIGH_CARD],
+    ["91765", HIGH_CARD],
+    ["62143", HIGH_CARD],
+    /* 
+      入力フォーマットに適してないやつは仕様が分からないので一旦役なしで判定
+      ・5文字すべて同じ数字
+      ・文字数が4以下、または6以上
+      ・半角数字でないものが入っている
+    */
+    ["55555", HIGH_CARD],
+    ["1234", HIGH_CARD],
+    ["123456", HIGH_CARD],
+    ["１２３４５", HIGH_CARD],
+    ["abcde", HIGH_CARD],
+    ["九蓮宝燈", HIGH_CARD],
+  ])("hand: %s should return %s", (hand, expected) => {
     const result = main(hand);
     expect(result).toEqual(expected);
   });

--- a/src/logic/qu1/execute.ts
+++ b/src/logic/qu1/execute.ts
@@ -1,53 +1,64 @@
-import { FOUR_OF_A_KIND, FULL_HOUSE, HIGH_CARD, ONE_PAIR, STRAIGHT, THREE_OF_A_KIND, TWO_PAIR } from './constants';
+import {
+  FOUR_OF_A_KIND,
+  FULL_HOUSE,
+  HIGH_CARD,
+  ONE_PAIR,
+  STRAIGHT,
+  THREE_OF_A_KIND,
+  TWO_PAIR,
+} from "./constants";
 
 /**
- * 
+ *
  * @param {string} hand 役を判定すべき手札
  * @returns {string} 役名.
  */
 export const main = (hand: string): string => {
-  const numberArray = hand.split('').map(char => parseInt(char));
+  // 入力フォーマットに適してないやつは潰す役なしで早期リターンする
+  if (!/^[1-9]{5}$/.test(hand)) {
+    return HIGH_CARD;
+  }
+  const numberArray = hand.split("").map((char) => parseInt(char));
 
   const counts: Record<number, number> = {};
   for (const num of numberArray) {
     counts[num] = (counts[num] || 0) + 1;
   }
 
-  let hasFour = false;
   let hasThree = false;
   let pairCount = 0;
 
   for (const key in counts) {
     const count = counts[key];
     if (count === 4) {
-      hasFour = true;
+      // 4カードの場合は他の役の可能性はないため、早期リターンでよい
+      return FOUR_OF_A_KIND;
     }
+
     if (count === 3) {
       hasThree = true;
     }
 
-    if (count >= 2) {
+    // 2以上だと後続の判定でペア役に吸われる可能性がある
+    if (count === 2) {
       pairCount++;
     }
   }
-  
-  if (pairCount === 1) {
-    return ONE_PAIR;
+
+  // 役に必要なcountが多い役から判定
+  if (hasThree) {
+    // フルハウスの判定が先
+    return pairCount === 1 ? FULL_HOUSE : THREE_OF_A_KIND;
   }
   if (pairCount === 2) {
     return TWO_PAIR;
   }
-  if (hasThree && pairCount === 2) {
-    return FULL_HOUSE;
-  }
-  if (hasThree) {
-    return THREE_OF_A_KIND;
-  }
-  if (hasFour) {
-    return FOUR_OF_A_KIND;
+  if (pairCount === 1) {
+    return ONE_PAIR;
   }
 
   const sorted = [...numberArray].sort((a, b) => a - b);
+  //ペアがないかを確認しているためこの判定でよい
   const isConsecutive = sorted[4] - sorted[0] === 4;
 
   if (isConsecutive) {
@@ -57,4 +68,4 @@ export const main = (hand: string): string => {
   return HIGH_CARD;
 };
 
-main('13535');
+main("13535");


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 実装内容
* 役判定で想定していない入力値を役なしで早期リターンで返すように
* 4カードの場合は他の役になりえないので早期リターンするように
* 3カード・フルハウスを`hasThree`の条件下で出しわけるように
* `pairCount`のカウント条件を`count>=2`から`count===2‘に(3カード・4カードも含まれてしまうため)
* 役判定を枚数の重複が多いものから判定(4カード→フルハウス・3カード→2ペア→1ペア→ストレート)
* メソッドの分割

## 備考


<!-- for GitHub Copilot review rule -->
<!-- レビューする際には、以下のprefix(接頭辞)を付け、この文字以外のprefixは使用しないこと
指摘事項はコメントにて投稿すること  
[MUST]: → からなず変更して(バグ・パフォーマンス・セキュリティー関連など)   
[IMO]: → 自分の意見だとこうだけど修正必須ではない
[NITS]: → 軽微な指摘
[Q]: → 質問  
[FYI]: → 参考情報  
[CON]: → 確認してほしいこと
-->
<!-- for GitHub Copilot review rule-->
<!-- I want to review in Japanese. -->
