### PR TITLE
ヴィジュネル暗号の課題実装を追加

### DIFF
--- a/src/logic/qu3/execute.ts
+++ b/src/logic/qu3/execute.ts
@@ -1,7 +1,39 @@
-import { Mode } from './constants';
+import { ALPHABET_SIZE, LOWERCASE_ALPHABET, Mode, UPPERCASE_ALPHABET } from './constants';
 
-export const main = (word: string, key: string, mode: Mode) => {
-  return 'Rijvs Uyvjn!'.replace('',word).replace('', key).replace('', mode);
+export const main = (text: string, key: string, mode: Mode): string => {
+  let result = '';
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    const keyChar = key[i % key.length];
+
+    const upperIndex = UPPERCASE_ALPHABET.indexOf(char);
+    const lowerIndex = LOWERCASE_ALPHABET.indexOf(char);
+
+    if (upperIndex === -1 && lowerIndex === -1) {
+      result += char;
+      continue;
+    }
+
+    const isUppercase = upperIndex !== -1;
+    const textCharIndex = isUppercase ? upperIndex : lowerIndex;
+    const keyCharIndex = LOWERCASE_ALPHABET.indexOf(keyChar.toLowerCase());
+
+    let newIndex;
+    if (mode === 'encrypt') {
+      newIndex = (textCharIndex + keyCharIndex) % ALPHABET_SIZE;
+    } else {
+      newIndex = (textCharIndex - keyCharIndex + ALPHABET_SIZE) % ALPHABET_SIZE;
+    }
+
+    if (isUppercase) {
+      result += UPPERCASE_ALPHABET[newIndex];
+    } else {
+      result += LOWERCASE_ALPHABET[newIndex];
+    }
+  }
+
+  return result;
 };
 
 main('Hello World!', 'key', 'encrypt');


### PR DESCRIPTION

技術育成支援のロジックテスト課題として、第4問のヴィジュネル暗号を実装しました。
課題の要件を定義した README.md、ロジック本体、およびJestによるテストコード一式を含みます。

変更内容

課題定義 (README.md) の追加

ヴィジュネル暗号の仕組み、ルール、入出力仕様、実装例を詳細に定義しました。


READMEの仕様に基づき、暗号化 (encrypt) ロジックを実装しました。

